### PR TITLE
Bookmarks: sort by radar number instead of bookmarkedDate

### DIFF
--- a/Ladybug/Model/RadarCollection.swift
+++ b/Ladybug/Model/RadarCollection.swift
@@ -148,7 +148,7 @@ class RadarCollection {
 
     public func bookmarks() -> [Radar] {
         let radars = self.radars.values.filter { $0.bookmarkedDate != nil }.sorted { (lhs, rhs) -> Bool in
-            return lhs.bookmarkedDate! > rhs.bookmarkedDate!
+            return lhs.number > rhs.number
         }
 
         return radars

--- a/Ladybug/Model/RadarNumber.swift
+++ b/Ladybug/Model/RadarNumber.swift
@@ -31,7 +31,13 @@ extension RadarNumber: Hashable {
 }
 
 public func == (lhs: RadarNumber, rhs: RadarNumber) -> Bool {
-    return lhs.rawValue == rhs.rawValue
+	return lhs.rawValue == rhs.rawValue
+}
+
+extension RadarNumber: Comparable {
+	public static func < (lhs: RadarNumber, rhs: RadarNumber) -> Bool {
+		return lhs.rawValue < rhs.rawValue
+	}
 }
 
 extension RadarNumber {


### PR DESCRIPTION
Especially when importing a large number of radars it's way more useful to sort by descending radar number instead of bookmarkedDate.