### PR TITLE
Fixed spelling of OpenRadarKeychain.presentRemoveKeyAlertController function

### DIFF
--- a/Ladybug/Extensions/OpenRadarKeychain+Extension.swift
+++ b/Ladybug/Extensions/OpenRadarKeychain+Extension.swift
@@ -41,7 +41,7 @@ extension OpenRadarKeychain {
         }
     }
 
-    static func presentRemoveKeyAlertContrller(on vc: UIViewController, completion: @escaping (_ success: Bool) -> Void) {
+    static func presentRemoveKeyAlertController(on vc: UIViewController, completion: @escaping (_ success: Bool) -> Void) {
         DispatchQueue.main.async {
             let alertController = UIAlertController(title: "Remove Open Radar API Key".localized(), message: "", preferredStyle: .alert)
             alertController.addAction(UIAlertAction(title: "Remove".localized(), style: .destructive, handler: { (_) in

--- a/Ladybug/Settings/SettingsViewController.swift
+++ b/Ladybug/Settings/SettingsViewController.swift
@@ -88,7 +88,7 @@ extension SettingsViewController {
         let openRadarAPIKeyViewModel = TableViewCellViewModel(title: "Open Radar API Key".localized(), subtitle: "Setup or remove the API Key".localized(), cellStyle: .subtitle, selectAction: {
 
             if OpenRadarKeychain.getAPIKey() != nil {
-                OpenRadarKeychain.presentRemoveKeyAlertContrller(on: self, completion: { (success) in
+                OpenRadarKeychain.presentRemoveKeyAlertController(on: self, completion: { (success) in
                     if success {
                         self.reloadData()
                         RadarCollection.shared.forceNotifyDelegates()


### PR DESCRIPTION
* Minor change in spelling for function from  ```OpenRadarKeychain.presentRemoveKeyAlertContrller``` to ```OpenRadarKeychain.presentRemoveKeyAlertController```